### PR TITLE
Added complete IRI to PrefixedName so you can use ==

### DIFF
--- a/aiosparql/__init__.py
+++ b/aiosparql/__init__.py
@@ -1,2 +1,2 @@
-__version__ = version = "0.2.0"
+__version__ = version = "0.3.0"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -53,10 +53,11 @@ class Syntax(unittest.TestCase):
                          2)
 
     def test_prefixed_name(self):
-        self.assertEqual(PrefixedName("foo", "bar"),
-                         PrefixedName("foo", "bar"))
-        self.assertEqual(len(set([PrefixedName("foo", "bar"),
-                                  PrefixedName("foo", "bar")])),
+        self.assertEqual(PrefixedName("foo", "bar", "baz"), IRI("foobaz"))
+        self.assertEqual(PrefixedName("foo", "bar", "baz"),
+                         PrefixedName("foo", "bar", "baz"))
+        self.assertEqual(len(set([PrefixedName("foo", "bar", "baz"),
+                                  PrefixedName("foo", "bar", "baz")])),
                          1)
 
     def test_rdf_term(self):


### PR DESCRIPTION
It is now possible to compare a PrefixedName with an IRI (and with a
str), it will actually compare against the full IRI.