### PR TITLE
IRI uses full str IRI for hashing

### DIFF
--- a/aiosparql/__init__.py
+++ b/aiosparql/__init__.py
@@ -1,2 +1,2 @@
-__version__ = version = "0.3.1"
+__version__ = version = "0.4.0"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/aiosparql/syntax.py
+++ b/aiosparql/syntax.py
@@ -148,7 +148,7 @@ class PrefixedName(RDFTerm):
             return self.iri() == other
 
     def __hash__(self):
-        return hash((self.prefix_label, self.local_part))
+        return hash(self.iri())
 
     def iri(self):
         return IRI(self.base_iri.value + self.local_part)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -59,6 +59,11 @@ class Syntax(unittest.TestCase):
         self.assertEqual(len(set([PrefixedName(IRI("foo"), "bar", "baz"),
                                   PrefixedName(IRI("foo"), "bar", "baz")])),
                          1)
+        mapping = {
+            "foobaz": "ok"
+        }
+        self.assertEqual(
+            mapping.get(PrefixedName(IRI("foo"), "bar", "baz"), "notok"), "ok")
 
     def test_rdf_term(self):
         self.assertEqual(RDFTerm("foo"), RDFTerm("foo"))


### PR DESCRIPTION
This can be very handy if you store an IRI in keys of a dict and want to
get the value from an str coming from a call to the database.