### PR TITLE
Fixed: allows using IRI in Node's subject

### DIFF
--- a/aiosparql/__init__.py
+++ b/aiosparql/__init__.py
@@ -1,2 +1,2 @@
-__version__ = version = "0.7.0"
+__version__ = version = "0.7.1"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/aiosparql/syntax.py
+++ b/aiosparql/syntax.py
@@ -65,7 +65,7 @@ class Node(list):
             if isinstance(o, Node):
                 extra_nodes.append(o)
         yield " ."
-        for node in sorted(extra_nodes, key=lambda x: x.subject):
+        for node in sorted(extra_nodes, key=lambda x: str(x.subject)):
             yield "\n\n"
             yield str(node)
 

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -18,10 +18,10 @@ class Syntax(unittest.TestCase):
                 rdf:type "doe" ."""))
 
     def test_node_in_node(self):
-        node1 = Node("john", [
+        node1 = Node(IRI("john"), [
             ("foo", "bar"),
         ])
-        node2 = Node("jane", [
+        node2 = Node(IRI("jane"), [
             ("foo", "bar"),
         ])
         node3 = Node("parent", [
@@ -30,13 +30,13 @@ class Syntax(unittest.TestCase):
             ("foo", "bar"),
         ])
         self.assertEqual(str(node3), dedent("""\
-            parent child1 john ;
-                child2 jane ;
+            parent child1 <john> ;
+                child2 <jane> ;
                 foo "bar" .
 
-            jane foo "bar" .
+            <jane> foo "bar" .
 
-            john foo "bar" ."""))
+            <john> foo "bar" ."""))
 
     def test_triples(self):
         triples = Triples([("john", RDF.type, "doe")])


### PR DESCRIPTION
It was mostly allowed but since I included the child nodes in the
rendering output, the sort command did not work as expected.