### PR TITLE
Fixed issue with first value of a Node & define iter()

### DIFF
--- a/aiosparql/__init__.py
+++ b/aiosparql/__init__.py
@@ -1,2 +1,2 @@
-__version__ = version = "0.7.1"
+__version__ = version = "0.8.0"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/aiosparql/syntax.py
+++ b/aiosparql/syntax.py
@@ -51,15 +51,13 @@ class Node(list):
 
     def _output_triples(self):
         extra_nodes = []
-        it = iter(sorted(self, key=self._group_key))
+        it = iter(self)
         p, o = next(it)
         yield "%s %s %s" % (self.subject, p, escape_any(o))
         if isinstance(o, Node):
             extra_nodes.append(o)
         for p, o in it:
             assert p is not None, "predicate not defined"
-            if o is None:
-                continue
             yield " ;\n"
             yield "    %s %s" % (p, escape_any(o))
             if isinstance(o, Node):
@@ -70,7 +68,13 @@ class Node(list):
             yield str(node)
 
     def _group_key(self, x):
-        return str(x[0])
+        return (str(x[0]), str(x[1]))
+
+    def __iter__(self):
+        for p, o in sorted(super().__iter__(), key=self._group_key):
+            if o is None:
+                continue
+            yield (p, o)
 
 
 class Triples(list):

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -8,9 +8,11 @@ from aiosparql.syntax import (
 class Syntax(unittest.TestCase):
     def test_node(self):
         node = Node("john", [
+            ("_first", None),
             (RDF.type, "doe"),
             ("foo", "bar"),
             ("foo", "baz"),
+            ("foo", None),
         ])
         self.assertEqual(str(node), dedent("""\
             john foo "bar" ;


### PR DESCRIPTION
If the first value has None for object, it should be ignored.

This commit also change the iterator you get from iter(node), it will
now order by predicate, then object and ignore None objects like the
rendering does.